### PR TITLE
passing display_grid

### DIFF
--- a/exe/connect_four
+++ b/exe/connect_four
@@ -3,5 +3,5 @@
 require 'bundler/setup'
 require 'connect_four'
 
-game = ConnectFour::Game.new(ARGV)
+game = ConnectFour::Game.new
 game.launch

--- a/lib/connect_four/board.rb
+++ b/lib/connect_four/board.rb
@@ -1,13 +1,11 @@
 module ConnectFour
   class Board
-    attr_reader :current_move, :size, :discs, :grid
+    attr_reader :current_move, :size, :grid
 
     def initialize
       # @ size = [rows, columns]
       @size = [6, 7]
-      # @discs is an array of disc objects
-      @discs = []
-      # @grid is array or arrays of nil or disc objects
+      # @grid is array or arrays of nil or player objects
       @grid = create_grid_from_size(size)
     end
 
@@ -19,13 +17,20 @@ module ConnectFour
     end
 
     def connect_four?
-      
+
       false
     end
 
     def full?
       # evaluate if the board is full
       false
+    end
+
+    def display_grid
+      system('clear')
+      print 'Move (L)eft or (R)ight then (Enter) to select where to drop your disc.'
+      print grid_string
+      collect_response
     end
 
     private
@@ -36,7 +41,7 @@ module ConnectFour
     end
 
     def update
-      # update the board's state based on the player's moee
+      # update the board's state based on the player's move
     end
 
     def create_grid_from_size(size_arr)
@@ -45,8 +50,25 @@ module ConnectFour
       Array.new(rows) { Array.new(columns) }
     end
 
-    def display_grid
-      string =
+    def display_disc(y,x)
+      disc = @grid[y][x]
+      disc.nil? ? ' ' : icons[disc.color.to_sym]
+    end
+
+    def collect_response
+      response = STDIN.gets.chomp.downcase
+      unless response == 'l' || response == 'r'
+        print "Please select only (L)eft or (R)ight (or Ctrl-C to quit)"
+        collect_response
+      end
+      response
+    end
+
+    def icons
+      { blue: '🔹', gold: '🔸' }
+    end
+
+    def grid_string
       %(
       |#{display_disc(0,0)} |#{display_disc(0,1)} |#{display_disc(0,2)} |#{display_disc(0,3)} |#{display_disc(0,4)} |#{display_disc(0,5)} |#{display_disc(0,6)} |
       |#{display_disc(1,0)} |#{display_disc(1,1)} |#{display_disc(1,2)} |#{display_disc(1,3)} |#{display_disc(1,4)} |#{display_disc(1,5)} |#{display_disc(1,6)} |
@@ -55,19 +77,6 @@ module ConnectFour
       |#{display_disc(4,0)} |#{display_disc(4,1)} |#{display_disc(4,2)} |#{display_disc(4,3)} |#{display_disc(4,4)} |#{display_disc(4,5)} |#{display_disc(4,6)} |
       |#{display_disc(5,0)} |#{display_disc(5,1)} |#{display_disc(5,2)} |#{display_disc(5,3)} |#{display_disc(5,4)} |#{display_disc(5,5)} |#{display_disc(5,6)} |
       )
-      system('clear')
-      print string
-      collect_response
-    end
-
-    def display_disc(y,x)
-      disc_at_xy = @grid[y][x]
-      disc_at_xy.nil? ? '   ' : disc_at_xy.player.icon
-    end
-
-    def collect_response
-      response = STDIN.gets.chomp
-      puts response
     end
   end
 end

--- a/lib/connect_four/game.rb
+++ b/lib/connect_four/game.rb
@@ -1,8 +1,9 @@
+require 'pry'
 module ConnectFour
   class Game
-    def initialize(players)
+    def initialize
       @board   = Board.new
-      @players = players.map { |name| Player.new(name) }
+      @players = []
       @current_player_index = 0
     end
 
@@ -17,7 +18,9 @@ module ConnectFour
     attr_reader :abort, :board, :players, :current_player_index
 
     def play
+      board.display_grid
       column = current_player.move
+      binding.pry
       return if move.empty?
 
       board.set_disc(column)
@@ -27,7 +30,13 @@ module ConnectFour
     end
 
     def welcome
-      puts "[Connect Four] #{players.map(&:name).join(' vs ')}"
+      names = []
+      puts 'Player 1 please enter your name:'
+      names << STDIN.gets.chomp.capitalize
+      puts 'Player 2 please enter your name:'
+      names << STDIN.gets.chomp.capitalize
+      create_players(names)
+      puts "[Connect Four] #{@players.map(&:name).join(' vs ')}"
       puts 'Ctrl-C to abort.'
       puts
     end
@@ -54,6 +63,11 @@ module ConnectFour
 
     def aborted?
       !!abort
+    end
+
+    def create_players(names_arr)
+      names_arr.each { |name| @players << Player.new(name) }
+      @players.each_with_index { |player, i| player.assign_color(i) }
     end
   end
 end

--- a/lib/connect_four/game.rb
+++ b/lib/connect_four/game.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module ConnectFour
   class Game
     def initialize
@@ -20,7 +19,6 @@ module ConnectFour
     def play
       board.display_grid
       column = current_player.move
-      binding.pry
       return if move.empty?
 
       board.set_disc(column)

--- a/lib/connect_four/player.rb
+++ b/lib/connect_four/player.rb
@@ -1,14 +1,21 @@
 module ConnectFour
   class Player
-    attr_reader :name
+    attr_reader :name, :color
+
 
     def initialize(name)
       @name = name
+      @color = nil
     end
 
     def move
       print "[#{name}]: "
-      STDIN.gets.chomp
+      STDIN.gets.chomp.downcase
+    end
+
+    def assign_color(index)
+      color_list =['blue', 'gold']
+      @color = color_list[index % color_list.length]
     end
   end
 end

--- a/spec/board_spec_helper.rb
+++ b/spec/board_spec_helper.rb
@@ -7,21 +7,28 @@ RSpec.configure do |config|
   end
 
   def winning_grid(type)
+    players = [player1, player2]
+    players.each_with_index { |player, i| player.assign_color(i) }
     grid = empty_grid(board.size)
 
     locations = case type
     when 'h'
-       { '1': [[5, 0], [5, 1], [5, 2], [5, 3]]}
+       { '1': [[5, 0], [5, 1], [5, 2], [5, 3]],
+         '2': [[5, 6], [5, 4], [5, 3]]
+       }
     when 'v'
-      {'1': [[5, 0], [4, 0], [3, 0], [2, 0]]}
+      { '1': [[5, 0], [4, 0], [3, 0], [2, 0]],
+        '2': [[5, 6], [5, 4], [5, 3]]
+      }
     when 'd'
       { '1': [[5, 1], [5, 2], [5, 3], [4, 2], [4, 3], [3, 3]],
         '2': [[5, 0], [4, 1], [3, 2], [2, 3]] }
     end
 
     locations.each do |player, values|
+      disc = player == '1'.to_sym ? players[0] : players[1]
       values.each do |pair|
-        grid[pair[0]][pair[1]] = player.to_s.to_i
+        grid[pair[0]][pair[1]] = disc
       end
     end
 

--- a/spec/connect_four/board_spec.rb
+++ b/spec/connect_four/board_spec.rb
@@ -3,10 +3,11 @@ require 'board_spec_helper'
 
 RSpec.describe ConnectFour::Board do
   let(:board) { ConnectFour::Board.new }
+  let(:player1) { ConnectFour::Player.new('alice') }
+  let(:player2) { ConnectFour::Player.new('bob') }
   let(:h_win) { winning_grid('h') }
   let(:v_win) { winning_grid('v') }
   let(:d_win) { winning_grid('d') }
-  let(:game) { ConnectFour::Game.new(['alice', 'bob']) }
 
   describe '#initialize' do
     it 'can initialize a board' do
@@ -14,7 +15,7 @@ RSpec.describe ConnectFour::Board do
     end
 
     it 'has correct attributes' do
-      expect(board).to have_attributes(size: [6, 7], discs: [], grid: empty_grid([6, 7]))
+      expect(board).to have_attributes(size: [6, 7], grid: empty_grid([6, 7]))
     end
   end
 
@@ -76,7 +77,8 @@ RSpec.describe ConnectFour::Board do
 
   describe '#display_grid' do
     before(:example) do
-      suppress_stdin('3')
+      allow(board).to receive(:system)
+      suppress_stdin('l')
     end
 
     it 'displays a grid with icons' do

--- a/spec/connect_four/game_spec.rb
+++ b/spec/connect_four/game_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe ConnectFour::Game do
+  let(:game) { ConnectFour::Game.new }
+
+  describe '#initialize' do
+    it 'can initialize a game' do
+    end
+
+    it 'has correct attributes' do
+
+    end
+  end
+end

--- a/spec/connect_four/player_spec.rb
+++ b/spec/connect_four/player_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe ConnectFour::Player do
+  let(:game) { ConnectFour::Game.new }
+  let(:player1) { ConnectFour::Player.new('alice') }
+
+  describe '#initialize' do
+    it 'can initialize a player' do
+    end
+
+    it 'has correct attributes' do
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
   end
 
   def suppress_stdout
-    allow(STDOUT).to receive(:puts) # this disables puts
+    allow(STDOUT).to receive(:puts)
     logger = double('STDOUT').as_null_object
     allow(STDOUT).to receive(:new).and_return(logger)
   end


### PR DESCRIPTION
After testing disc class, I realized that having it would mean location of discs would be held in two diff locations. To minimize errors, disc class was removed. Grid now contains either nil or an instance of the player class.